### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ homepage = "https://github.com/smol-rs/cache-padded"
 documentation = "https://docs.rs/cache-padded"
 keywords = ["cache", "padding", "lock-free", "atomic"]
 categories = ["concurrency", "no-std"]
-readme = "README.md"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.