### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+env:
+  RUSTFLAGS: -D warnings
+  RUST_BACKTRACE: 1
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'smol-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - run: cargo package
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.2.0
+
+- Improve implementation of `CachePadded`.
+
 # Version 1.1.1
 
 - Forbid unsafe code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "cache-padded"
-version = "1.1.1"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Create "v1.x.y" git tag
+version = "1.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Prevent false sharing by padding and aligning to the length of a cache line"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ description = "Prevent false sharing by padding and aligning to the length of a 
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/cache-padded"
 homepage = "https://github.com/smol-rs/cache-padded"
-documentation = "https://docs.rs/cache-padded"
 keywords = ["cache", "padding", "lock-free", "atomic"]
 categories = ["concurrency", "no-std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@
 //!
 //! Cache lines are assumed to be N bytes long, depending on the architecture:
 //!
-//! * On x86-64 and aarch64, N = 128.
-//! * On all others, N = 64.
+//! * On x86-64, aarch64, and powerpc64, N = 128.
+//! * On arm, mips, mips64, and riscv64, N = 32.
+//! * On s390x, N = 256.
 //!
 //! Note that N is just a reasonable guess and is not guaranteed to match the actual cache line
 //! length of the machine the program is running on.
@@ -67,14 +68,63 @@ use core::ops::{Deref, DerefMut};
 // - https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-optimization-manual.pdf
 // - https://github.com/facebook/folly/blob/1b5288e6eea6df074758f877c849b6e73bbb9fbb/folly/lang/Align.h#L107
 //
-// ARM's big.LITTLE architecture has asymmetric cores and "big" cores have 128-byte cache lines.
+// ARM's big.LITTLE architecture has asymmetric cores and "big" cores have 128-byte cache line size.
 //
 // Sources:
 // - https://www.mono-project.com/news/2016/09/12/arm64-icache/
 //
-#[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(align(128)))]
+// powerpc64 has 128-byte cache line size.
+//
+// Sources:
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_ppc64x.go#L9
 #[cfg_attr(
-    not(any(target_arch = "x86_64", target_arch = "aarch64")),
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64",
+    ),
+    repr(align(128))
+)]
+// arm, mips, mips64, and riscv64 have 32-byte cache line size.
+//
+// Sources:
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_arm.go#L7
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips.go#L7
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mipsle.go#L7
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips64x.go#L9
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_riscv64.go#L7
+#[cfg_attr(
+    any(
+        target_arch = "arm",
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "riscv64",
+    ),
+    repr(align(32))
+)]
+// s390x has 256-byte cache line size.
+//
+// Sources:
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_s390x.go#L7
+#[cfg_attr(target_arch = "s390x", repr(align(256)))]
+// x86 and wasm have 64-byte cache line size.
+//
+// Sources:
+// - https://github.com/golang/go/blob/dda2991c2ea0c5914714469c4defc2562a907230/src/internal/cpu/cpu_x86.go#L9
+// - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_wasm.go#L7
+//
+// All others are assumed to have 64-byte cache line size.
+#[cfg_attr(
+    not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "powerpc64",
+        target_arch = "arm",
+        target_arch = "mips",
+        target_arch = "mips64",
+        target_arch = "riscv64",
+        target_arch = "s390x",
+    )),
     repr(align(64))
 )]
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]


### PR DESCRIPTION
- CachePadded: update alignment based on golang's CacheLinePadSize a17da7a96abb7a8a81ff5a8ed0a464101792d740
- Remove doc URL from Cargo.toml d155ff45a7b35e2d7ee10daa9b6c9404ef6e6870
- Create GitHub release automatically 3c133de35d7e354e30ed7da808c826de2eeefb76
- Release 1.2.0 e46bde6372b869e1de50cca247779a3482e1d3a6