### PR TITLE
Deprecate in favor of crossbeam-utils

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings -A deprecated
   RUSTDOCFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.3.0
+
+- This crate is now deprecated in favor of [crossbeam-utils::CachePadded](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).
+
 # Version 1.2.0
 
 - Improve implementation of `CachePadded`. (#8)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cache-padded"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.31"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cache-padded
+# cache-padded (deprecated)
 
 [![Build](https://github.com/smol-rs/cache-padded/workflows/Build%20and%20test/badge.svg)](
 https://github.com/smol-rs/cache-padded/actions)
@@ -8,6 +8,8 @@ https://github.com/smol-rs/cache-padded)
 https://crates.io/crates/cache-padded)
 [![Documentation](https://docs.rs/cache-padded/badge.svg)](
 https://docs.rs/cache-padded)
+
+**This crate is now deprecated in favor of [crossbeam-utils::CachePadded](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html).**
 
 Prevent false sharing by padding and aligning to the length of a cache line.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,10 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![deprecated(
+    since = "1.3.0",
+    note = "This crate is now deprecated in favor of [crossbeam-utils::CachePadded](https://docs.rs/crossbeam-utils/latest/crossbeam_utils/struct.CachePadded.html)."
+)]
 
 use core::fmt;
 use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
With the release of `concurrent-queue` version 2, there are no major users of this crate left. This PR officially deprecates this crate.

Closes #10 